### PR TITLE
Use of primitives in mothers and body in domain events

### DIFF
--- a/src/contexts/example-context/src/example-aggregate/application/create/createExampleAggregateCommand.mother.ts
+++ b/src/contexts/example-context/src/example-aggregate/application/create/createExampleAggregateCommand.mother.ts
@@ -1,5 +1,3 @@
-import Datetime from '@context/shared/domain/datetime';
-import DatetimeMother from '@context/shared/domain/datetime.mother';
 import CreateExampleAggregateCommand, {
     CreateExampleAggregateCommandParams
 } from '@src/example-aggregate/application/create/createExampleAggregateCommand';
@@ -12,16 +10,17 @@ export default class CreateExampleAggregateCommandMother {
         return new CreateExampleAggregateCommand(params);
     }
 
-    static random(overwrites?: { id?: string }): CreateExampleAggregateCommand {
-        const id = overwrites?.id ? overwrites.id : ExampleAggregateIdMother.random().value;
-
-        return CreateExampleAggregateCommandMother.create({ id });
+    static random(overwrites?: Partial<CreateExampleAggregateCommandParams>): CreateExampleAggregateCommand {
+        return CreateExampleAggregateCommandMother.create({
+            id: ExampleAggregateIdMother.random().value,
+            ...overwrites
+        });
     }
 
-    static applyCommand(command: CreateExampleAggregateCommand, context: { createdAt: Datetime }): ExampleAggregate {
-        const id = ExampleAggregateIdMother.create(command.id),
-            createdAt = DatetimeMother.create(context.createdAt.value);
-
-        return ExampleAggregateMother.create(id, createdAt);
+    static applyCommand(command: CreateExampleAggregateCommand, context: { createdAt: string }): ExampleAggregate {
+        return ExampleAggregateMother.create({
+            ...command,
+            ...context
+        });
     }
 }

--- a/src/contexts/example-context/src/example-aggregate/application/create/exampleAggregateCreator.test.ts
+++ b/src/contexts/example-context/src/example-aggregate/application/create/exampleAggregateCreator.test.ts
@@ -43,7 +43,7 @@ describe('exampleAggregateCreator', () => {
             handler = new CreateExampleAggregateCommandHandler(new ExampleAggregateCreator(clock, repository, eventBus)),
             command = CreateExampleAggregateCommandMother.random(),
             createdAt = DatetimeMother.random(),
-            expected = CreateExampleAggregateCommandMother.applyCommand(command, { createdAt });
+            expected = CreateExampleAggregateCommandMother.applyCommand(command, { createdAt: createdAt.value });
 
         clock.whenNowThenReturn(createdAt);
         repository.whenSearchThenReturn(null);
@@ -63,7 +63,7 @@ describe('exampleAggregateCreator', () => {
             command = CreateExampleAggregateCommandMother.random(),
             createdAt = DatetimeMother.random(),
             expected = ExampleAggregateCreatedDomainEventMother.fromExampleAggregate(
-                CreateExampleAggregateCommandMother.applyCommand(command, { createdAt })
+                CreateExampleAggregateCommandMother.applyCommand(command, { createdAt: createdAt.value })
             );
 
         clock.whenNowThenReturn(createdAt);

--- a/src/contexts/example-context/src/example-aggregate/domain/exampleAggregate.mother.ts
+++ b/src/contexts/example-context/src/example-aggregate/domain/exampleAggregate.mother.ts
@@ -1,18 +1,19 @@
-import ExampleAggregateId from '@src/example-aggregate/domain/exampleAggregateId';
-import Datetime from '@context/shared/domain/datetime';
 import ExampleAggregate from '@src/example-aggregate/domain/exampleAggregate';
 import ExampleAggregateIdMother from '@src/example-aggregate/domain/exampleAggregateId.mother';
 import DatetimeMother from '@context/shared/domain/datetime.mother';
+import { ExampleAggregatePrimitives } from '@src/example-aggregate/domain/exampleAggregatePrimitives';
+import { RecursivePartial } from '@context/shared/domain/recursivePartial.mother';
 
 export default class ExampleAggregateMother {
-    static create(id: ExampleAggregateId, createdAt: Datetime): ExampleAggregate {
-        return new ExampleAggregate(id, createdAt);
+    static create(primitives: ExampleAggregatePrimitives): ExampleAggregate {
+        return ExampleAggregate.fromPrimitives(primitives);
     }
 
-    static random(): ExampleAggregate {
-        const id = ExampleAggregateIdMother.random(),
-            createdAt = DatetimeMother.random();
-
-        return ExampleAggregateMother.create(id, createdAt);
+    static random(overwrites?: RecursivePartial<ExampleAggregatePrimitives>): ExampleAggregate {
+        return ExampleAggregateMother.create({
+            id: ExampleAggregateIdMother.random().value,
+            createdAt: DatetimeMother.random().value,
+            ...overwrites
+        });
     }
 }

--- a/src/contexts/example-context/src/example-aggregate/domain/exampleAggregateCreatedDomainEvent.ts
+++ b/src/contexts/example-context/src/example-aggregate/domain/exampleAggregateCreatedDomainEvent.ts
@@ -6,28 +6,23 @@ type CreateExampleAggregateDomainEventBody = Readonly<Omit<ExampleAggregatePrimi
 export default class ExampleAggregateCreatedDomainEvent extends DomainEvent {
     static readonly EVENT_NAME = 'company.service.1.event.exampleAggregate.created';
 
-    readonly createdAt: string;
+    readonly body: CreateExampleAggregateDomainEventBody;
 
-    constructor({
-        id,
-        createdAt,
-        eventId,
-        occurredOn
-    }: ExampleAggregatePrimitives & {
+    constructor(args: ExampleAggregatePrimitives & {
         eventId?: string;
         occurredOn?: Date;
     }) {
+        const {
+            id, eventId, occurredOn, ...body
+        } = args;
+
         super(ExampleAggregateCreatedDomainEvent.EVENT_NAME, id, eventId, occurredOn);
 
-        this.createdAt = createdAt;
+        this.body = body;
     }
 
     toPrimitives(): CreateExampleAggregateDomainEventBody {
-        const { createdAt } = this;
-
-        return {
-            createdAt
-        };
+        return this.body;
     }
 
     static fromPrimitives(

--- a/src/contexts/shared/src/domain/recursivePartial.mother.ts
+++ b/src/contexts/shared/src/domain/recursivePartial.mother.ts
@@ -1,0 +1,3 @@
+export type RecursivePartial<T> = {
+    [P in keyof T]?: RecursivePartial<T[P]>;
+};


### PR DESCRIPTION
Adding the following changes:

- `ExampleAggregateCreatedDomainEvent` now has only a property -apart from parent ones-  `body` that encapsulates the rest of the properties.
- `ExampleAggregateMother` now uses primitives in the `create` method which creates the aggregate invoking the `fromPrimitives` method in `ExampleAggregate` and partial primitives  can be passed to random method to override random ones.
- `CreateExampleAggregateMother applyCommand` method now directly unpacks command and context args to create the aggregate through its mother. 
- `RecursivePartial` type has been created to be able to pass partial nested parameters into mother's random methods. Declared inside mother file to avoid usage in production code.

All these changes reduce the need to change mothers/events in case its related aggregates properties change.